### PR TITLE
Changes to package.json and added express to serve application on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A react chat web app",
   "main": "index.js",
   "scripts": {
-    "start": "webpack serve",
+    "start": "node server.js",
+    "dev": "webpack serve",
+    "heroku-postbuild": "webpack",
     "test": "jest"
   },
   "repository": {
@@ -22,6 +24,9 @@
   "bugs": {
     "url": "https://github.com/flydevs/chat-app-web/issues"
   },
+  "engines": {
+    "node": "12.13.0 - 16.13.0"
+  },
   "homepage": "https://github.com/flydevs/chat-app-web#readme",
   "dependencies": {
     "@babel/core": "^7.15.8",
@@ -36,6 +41,7 @@
     "@types/testing-library__jest-dom": "^5.14.1",
     "babel-loader": "^8.2.3",
     "css-loader": "^6.4.0",
+    "express": "^4.17.1",
     "html-webpack-plugin": "^5.4.0",
     "jest-css-modules": "^2.1.0",
     "node-sass": "^6.0.1",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+var path = require('path');
+
+var express = require('express');
+
+
+var app = express();
+
+
+app.use(express.static(path.join(__dirname, 'dist')));
+
+app.set('port', process.env.PORT || 8080);
+
+
+var server = app.listen(app.get('port'), function() {
+
+  console.log('listening on port ', server.address().port);
+
+});


### PR DESCRIPTION
Now node has to be between 12.13 and 16.13. 
Webpack dist/ files are created on the run by Heroku, so running yarn run start (node server.js) locally wont work, instead use yarn run dev (webpack serve) or run webpack before start.